### PR TITLE
We should still allow images to specify a width.

### DIFF
--- a/scss/_base/_typography.scss
+++ b/scss/_base/_typography.scss
@@ -162,7 +162,6 @@ a {
 img {
   display: block;
   max-width: 100%;
-  width: auto;
   height: auto;
 }
 


### PR DESCRIPTION
# Changes
- Remove forced `auto` width on images. (Most `<img>` tags will have default value of `auto` for width anyways, but if HTML attribute specifies a width, this rule will now no longer override it).

For review: @DoSomething/front-end 