### PR TITLE
Mobile galleries should still have padding.

### DIFF
--- a/scss/_modules/_gallery.scss
+++ b/scss/_modules/_gallery.scss
@@ -12,6 +12,7 @@
 
   > li {
     margin: gutter() 0;
+    padding: 0 gutter();
   }
 
   // Quartet Gallery. Four items per row.


### PR DESCRIPTION
# Changes
- Gallery items should still have padding on mobile.

Note: Going to make a followup PR to make `.media.-medium` look nicer on mobile!

For review: @DoSomething/front-end 

# Screenshots
#### Not Good:
![screen shot 2015-01-22 at 10 14 56 am](https://cloud.githubusercontent.com/assets/583202/5858240/9e09dde6-a21f-11e4-870d-86cf7e6f4bc4.png)

#### Lookin' Great:
![screen shot 2015-01-22 at 10 15 00 am](https://cloud.githubusercontent.com/assets/583202/5858243/a060a6f6-a21f-11e4-8633-020fab1cd6a9.png)
