### PR TITLE
Adjust modal close buttons to be sized with banners.

### DIFF
--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -62,11 +62,15 @@
   position: absolute;
   top: 0;
   right: $base-spacing;
-  font-size: 45px;
+  font-size: 36px;
   font-weight: bold;
   color: $med-gray;
   opacity: 0.4;
   text-decoration: none;
+
+  @include media($medium) {
+    font-size: 42px;
+  }
 
   &:hover {
     text-decoration: none;


### PR DESCRIPTION
# Changes
 - Adjusts modal close buttons to be sized with banners. Fixes DoSomething/dosomething#3770.

##### Desktop:
![screen shot 2015-01-23 at 1 38 17 pm](https://cloud.githubusercontent.com/assets/583202/5880284/2381eb68-a305-11e4-97b5-87e4c083c598.png)

##### Mobile:
![screen shot 2015-01-23 at 1 37 46 pm](https://cloud.githubusercontent.com/assets/583202/5880285/26e959a8-a305-11e4-9bbf-08374afd39dd.png)
