### PR TITLE
Fixes styleguide nav issue in Chrome/IE.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "html5shiv": "~3.7.2",
     "respond": "~1.4.2",
     "highlightjs": "~8.0.0",
-    "filament-sticky": "~0.1.3"
+    "filament-sticky": "~0.1.4"
   },
   "resolutions": {
     "jquery": "1.8.3"

--- a/scss/styleguide.scss
+++ b/scss/styleguide.scss
@@ -16,24 +16,6 @@
 @import "_utilities/mixins";
 
 // FixedSticky
-.fixedsticky {
-  position: -webkit-sticky;
-  position: -moz-sticky;
-  position: -ms-sticky;
-  position: -o-sticky;
-  position: sticky;
-}
-
-.fixedsticky-withoutfixedfixed .fixedsticky-off,
-.fixed-supported .fixedsticky-off {
-  position: static;
-}
-
-.fixedsticky-withoutfixedfixed .fixedsticky-on,
-.fixed-supported .fixedsticky-on {
-  position: fixed;
-}
-
 .fixedsticky-dummy {
   display: none;
 }
@@ -44,26 +26,48 @@
 
 
 // Styleguide!
+main {
+  @include clearfix;
+}
 
 .styleguide-sidebar {
   padding-top: $base-spacing;
 
   @include media($tablet) {
-    position: -webkit-sticky;
+    @include span(4 rtl);
     position: sticky;
     top: 0;
 
-    @include span(5 at 12 isolate);
+    // Fallback for position:sticky, through Filament Group's fixed-sticky
+    &.fixedsticky-on {
+      position: fixed;
+      width: 100%;
+      max-width: 1440px;
+      padding: 0;
+
+      .waypoints {
+        position: absolute;
+        width: span(4);
+        padding: $base-spacing gutter();
+        right: 0;
+        display: inline-block;
+      }
+    }
+
+    &.fixedsticky-off {
+      position: static;
+    }
   }
 }
 
 .styleguide-content {
-  margin: $base-spacing;
-
   @include clearfix;
+  @include span(100%);
+  padding-top: $base-spacing;
 
   @include media($tablet) {
-    @include span(9 at 3 isolate);
+    @include span(10);
+    @include push(2);
   }
 
   // Override galleries in styleguide content to fit to grid.

--- a/styleguide/layout.erb
+++ b/styleguide/layout.erb
@@ -72,13 +72,14 @@
       </div>
     </header>
 
-    <%= yield %>
+    <main>
+      <%= yield %>
+    </main>
 
   </div>
 </div>
 
 <script type="text/javascript" src="bower_components/jquery/jquery.min.js"></script>
-<script type="text/javascript" src="bower_components/filament-fixed/fixedfixed.js"></script>
 <script type="text/javascript" src="bower_components/filament-sticky/fixedsticky.js"></script>
 
 <script type="text/javascript" src="dist/neue.js"></script>

--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -1,6 +1,6 @@
 module.exports = {
   all: {
-    src: "dist/neue.css",
+    src: ["dist/neue.css", "dist/styleguide.css"],
     options: {
       map: false,
       processors: [


### PR DESCRIPTION
# Changes
 - Fixes issue where pesky sticky nav would escape(!) the page container in browsers that didn't support `position: sticky`. Yikes.

For review: @DoSomething/front-end 