### PR TITLE
Form refactoring

### DIFF
--- a/js/validation.js
+++ b/js/validation.js
@@ -47,9 +47,9 @@ define(function(require) {
   var prepareLabel = function($label) {
     // Check to make sure we haven't already prepared this before
     if($label.find(".inner-label").length === 0) {
-      var $innerLabel = $("<div class='inner-label'></div>");
-      $innerLabel.append("<div class='label'>" + $label.html() + "</div>");
-      $innerLabel.append("<div class='message'></div>");
+      var $innerLabel = $("<div class='validation'></div>");
+      $innerLabel.append("<div class='validation__label'>" + $label.html() + "</div>");
+      $innerLabel.append("<div class='validation__message'></div>");
 
       $label.html($innerLabel);
     }
@@ -151,20 +151,20 @@ define(function(require) {
    */
   var showValidationMessage = function($field, result) {
     var $fieldLabel = $("label[for='" + $field.attr("id") + "']");
-    var $fieldMessage = $fieldLabel.find(".message");
+    var $fieldMessage = $fieldLabel.find(".validation__message");
     var fieldLabelHeight = $fieldLabel.height();
     var fieldMessageHeight;
 
-    $field.removeClass("success error warning shake");
-    $fieldMessage.removeClass("success error warning");
+    $field.removeClass("-success -error -warning shake");
+    $fieldMessage.removeClass("-success -error -warning");
 
     // Highlight/animate field
     if(result.success === true) {
-      $field.addClass("success");
+      $field.addClass("-success");
       $fieldMessage.addClass("success");
     } else {
-      $field.addClass("error");
-      $fieldMessage.addClass("error");
+      $field.addClass("-error");
+      $fieldMessage.addClass("-error");
 
       if( isFormField($field) ) {
         $field.addClass("shake");
@@ -194,7 +194,7 @@ define(function(require) {
     }
 
     // Animate in the validation message
-    $fieldLabel.addClass("show-message");
+    $fieldMessage.addClass("is-showing-message");
 
     $(".js-mailcheck-fix").on("click", function(e) {
       e.preventDefault();
@@ -209,8 +209,8 @@ define(function(require) {
     });
 
     $field.on("focus", function() {
-      $field.removeClass("warning error success shake");
-      $fieldLabel.removeClass("show-message");
+      $field.removeClass("-warning -error -success shake");
+      $fieldMessage.removeClass("is-showing-message");
       $fieldLabel.css("height", "");
     });
 

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -1,11 +1,15 @@
 // A label and a form element.
 //
-// .-inline - Form elements appear side-by-side.
 // .-padded - Adds extra padding above and below field group.
+// .-inline - Form elements appear side-by-side.
 //
 // Styleguide Forms - Field Groups
 .field-group {
   margin-bottom: ($base-spacing / 2);
+
+  &.-padded {
+    margin: $base-spacing 0;
+  }
 
   &.-inline {
     .field-label {
@@ -36,10 +40,6 @@
       padding: 0.5em 1em 0.45em;
       margin: 0 ($base-spacing / 2);
     }
-  }
-
-  &.-padded {
-    margin: $base-spacing 0;
   }
 }
 

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -46,12 +46,12 @@
 
 // Labels for form elements. Optional validation styles triggered by client-side validation.
 //
-// .success    - Successful form validation
-// .warning    - Warning form validation (not an error, but worth double-checking).
-// .error      - Something's wrong!
+// .-success    - Successful form validation
+// .-warning    - Warning form validation (not an error, but worth double-checking).
+// .-error      - Something's wrong!
 //
-// Styleguide Forms - Form Labels
-label {
+// Styleguide Forms - Field Labels
+.field-label {
   display: block;
   clear: both;
   width: 100%;
@@ -62,34 +62,30 @@ label {
   overflow: hidden;
   transition: height 0.5s;
 
-  .inner-label {
-    position: relative;
-    transition: top 0.5s;
-  }
-
-  &.show-message {
-    .inner-label {
-      top: -1.5em;
-    }
-  }
-
   em {
     font-style: normal;
     color: $med-gray;
   }
+}
 
-  .message {
-    &.error {
-      color: $error-color;
-    }
+// Validation styles
+// @see: validation.js
+.validation {
+  position: relative;
+  transition: top 0.5s;
 
-    &.warning {
-      color: $purple;
-    }
+  &.is-showing-message {
+    top: -1.5em;
+  }
+}
 
-    &.success {
-      color: $purple;
-    }
+.validation__message {
+  &.-error {
+    color: $error-color;
+  }
+
+  &.-warning, &.-success {
+    color: $purple;
   }
 }
 
@@ -100,6 +96,7 @@ label {
 // :focus         - Field is selected for text input
 // .short         - Short input width (e.g. for zip codes)
 // .medium        - Medium-sized input width (e.g. for phone numbers)
+// .-error        - Error styling, used for validation issues.
 //
 // Styleguide Forms - Text Input Fields
 input[type="email"], input[type="number"], input[type="password"], input[type="search"],
@@ -136,9 +133,11 @@ input[type="time"], input[type="week"], textarea {
   }
 
   &.error {
+  &.-error {
     border-color: $error-color;
   }
 }
+
 
 // Specific style rules for search input fields.
 //

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -290,9 +290,3 @@ select {
   }
 }
 
-// Wrapping a group of checkboxes or radio buttons in `.option` adds proper bottom margins.
-.option-group {
-  margin-bottom: $base-spacing / 2;
-}
-
-

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -57,7 +57,7 @@
   width: 100%;
   font-size: 16px;
   font-weight: 600;
-  margin: 1em 0 0.25em;
+  margin: 0 0 ($base-spacing / 4);
   height: 1.5em;
   overflow: hidden;
   transition: height 0.5s;
@@ -108,7 +108,7 @@ input[type="time"], input[type="week"], textarea {
   border-radius: $lg-border-radius;
   background-clip: padding-box;
   padding: 0.5em 1em;
-  margin: 0 0 ($base-spacing / 2);
+  margin: 0;
   transition: border 0.5s;
 
   // Fixes styling in Firefox/Safari; non-standard properties so not autoprefixed.
@@ -166,6 +166,7 @@ input[type="submit"] {
   white-space: normal;
 }
 
+
 // Select boxes present a list of options on a form.
 //
 // Styleguide Forms - Select Boxes
@@ -176,7 +177,7 @@ select {
   font-size: $font-regular;
   font-family: $font-proxima-nova;
   border: 1px solid $light-gray;
-  margin: 0 0 ($base-spacing / 2);
+  margin: 0;
 
   &:focus {
     outline: none;
@@ -189,10 +190,10 @@ select {
   }
 }
 
+
 // Checkboxes and radio boxes.
 //
 // Styleguide Forms - Option Fields
-
 .option {
   position: relative;
   display: inline-block;

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -90,12 +90,9 @@
 }
 
 
-// Text input fields. Defaults to full-width, but can be modified to be smaller
-// if necessary (use sparingly, it's generally best to fit to grid container).
+// Text input fields.
 //
 // :focus         - Field is selected for text input
-// .short         - Short input width (e.g. for zip codes)
-// .medium        - Medium-sized input width (e.g. for phone numbers)
 // .-error        - Error styling, used for validation issues.
 //
 // Styleguide Forms - Text Input Fields
@@ -124,15 +121,6 @@ input[type="time"], input[type="week"], textarea {
     box-shadow: 0 0 3px $blue;
   }
 
-  &.short {
-    max-width: 80px;
-  }
-
-  &.medium {
-    max-width: 200px;
-  }
-
-  &.error {
   &.-error {
     border-color: $error-color;
   }

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -1,3 +1,49 @@
+// A label and a form element.
+//
+// .-inline - Form elements appear side-by-side.
+// .-padded - Adds extra padding above and below field group.
+//
+// Styleguide Forms - Field Groups
+.field-group {
+  margin-bottom: ($base-spacing / 2);
+
+  &.-inline {
+    .field-label {
+      display: inline-block;
+      width: auto;
+      margin: ($base-spacing / 2) ($base-spacing /2) ($base-spacing / 2) 0;
+    }
+
+    input[type="email"], input[type="number"], input[type="password"], input[type="search"],
+    input[type="tel"], input[type="text"], input[type="url"], input[type="color"],
+    input[type="date"], input[type="datetime"], input[type="datetime-local"], input[type="month"],
+    input[type="time"], input[type="week"], textarea {
+      width: auto;
+    }
+
+    .option {
+      display: inline-block;
+    }
+
+    .option, .button {
+      + .option,  + .button {
+        margin-left: ($base-spacing / 2);
+      }
+    }
+
+    .button {
+      font-size: $font-regular;
+      padding: 0.5em 1em 0.45em;
+      margin: 0 ($base-spacing / 2);
+    }
+  }
+
+  &.-padded {
+    margin: $base-spacing 0;
+  }
+}
+
+
 // Labels for form elements. Optional validation styles triggered by client-side validation.
 //
 // .success    - Successful form validation

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -196,7 +196,7 @@ select {
 // Styleguide Forms - Option Fields
 .option {
   position: relative;
-  display: inline-block;
+  display: block;
   height: auto;
   padding-left: $base-spacing;
   margin: ($base-spacing / 4) 0;

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -129,6 +129,13 @@
     <!-- .show-message and .message classes and markup generated dynamically -->
     <label class="show-message">
       <div class="message $modifier_class">Label</div>
+  <% styleguide_block  'Forms - Field Groups' do %>
+    <div class="field-group $modifier_class">
+      <label class="field-label">Form Label</label>
+      <input type="text">
+    </div>
+  <% end %>
+
     </label>
     <input class="$modifier_class" type="text">
   <% end %>

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -165,7 +165,7 @@
 
   <% styleguide_block  'Forms - Option Fields' do %>
     <h4>Some checkboxes</h4>
-    <div class="option-group">
+    <div class="field-group">
       <label class="option -checkbox">
         <input checked type="checkbox" id="option1">
         <span class="option__indicator"></span>
@@ -186,7 +186,7 @@
     </div>
 
     <h4>Some radio options</h4>
-    <div class="option-group">
+    <div class="field-group">
       <label class="option -radio">
         <input checked type="radio" name="choice" id="choice1">
         <span class="option__indicator"></span>

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -143,7 +143,6 @@
   <% end %>
 
   <% styleguide_block  'Forms - Text Input Fields' do %>
-    <input type="text" class="$modifier_class">
     <input type="text" class="$modifier_class" placeholder="placeholder">
   <% end %>
 

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -125,10 +125,6 @@
   <% end %>
 
   <h3 id="forms">Forms</h3>
-  <% styleguide_block  'Forms - Form Labels' do %>
-    <!-- .show-message and .message classes and markup generated dynamically -->
-    <label class="show-message">
-      <div class="message $modifier_class">Label</div>
   <% styleguide_block  'Forms - Field Groups' do %>
     <div class="field-group $modifier_class">
       <label class="field-label">Form Label</label>
@@ -136,6 +132,12 @@
     </div>
   <% end %>
 
+  <% styleguide_block  'Forms - Field Labels' do %>
+    <!-- validation classes and markup generated dynamically -->
+    <label class="field-label">
+      <span class="validation">
+        <div class="validation__message $modifier_class">Label</div>
+      </span>
     </label>
     <input class="$modifier_class" type="text">
   <% end %>


### PR DESCRIPTION
# Changes
 - Add __field group__ pattern – universal "container" for individual field items (i.e. label + input element). All spacing between field elements should be handled by "field groups" now, instead of having bottom-margins on individual elements.
 - Adds `.-inline` field group modifier for single-line forms (such as search fields, or filters).
 - Adds `.-padded` field group modifier for form elements within page layouts.
 - Refactors validation classes to prepare for decoupling this code in the future.
 - Remove unused `short` and `medium` modifiers on input fields.

For review: @DoSomething/front-end

# Screenshots
#### Field Groups
![screen shot 2015-01-29 at 4 58 27 pm](https://cloud.githubusercontent.com/assets/583202/5967413/b1a3a614-a7da-11e4-92aa-3e0d1b97ac7d.png)

![screen shot 2015-01-29 at 5 20 54 pm](https://cloud.githubusercontent.com/assets/583202/5967464/34fba5f2-a7db-11e4-8b1e-1c0306181002.png)

![screen shot 2015-01-29 at 4 59 12 pm](https://cloud.githubusercontent.com/assets/583202/5967416/b5b06918-a7da-11e4-8f10-db0dd61ee4b9.png)
