### PR TITLE
Update button state classes to follow naming convention.

### DIFF
--- a/js/validation.js
+++ b/js/validation.js
@@ -228,13 +228,7 @@ define(function(require) {
 
     // Disable that guy
     $submitButton.attr("disabled", true);
-    $submitButton.addClass("loading");
-
-    // If <button>, add a loading style
-    if($submitButton.prop("tagName") === "BUTTON") {
-      // Neue's `.loading` class only works on <a> or <button> :(
-      $submitButton.addClass("loading");
-    }
+    $submitButton.addClass("is-loading");
   };
 
 

--- a/scss/_components/_button.scss
+++ b/scss/_components/_button.scss
@@ -4,10 +4,10 @@
 // :hover             - Suble hover state (will not be displayed on touch interfaces)
 // :focus             - Focus state for users navigating the page using tab keys.
 // :active            - "Pushed" button state
-// .disabled          - Disabled (non-interactive) button state. Consider removing button from interface if not necessary to avoid confusion.
-// .-loading           - AJAX loading animation. Used when loading results inline.
-// .-secondary         - Should be used if not the main call-to-action on a page.
-// .-tertiary          - Used to de-emphasize button (for example, a "cancel" option), but still show inline with other fields.
+// .is-disabled       - Disabled (non-interactive) button state. Consider removing button from interface if not necessary to avoid confusion.
+// .is-loading        - AJAX loading animation. Used when loading results inline.
+// .-secondary        - Should be used if not the main call-to-action on a page.
+// .-tertiary         - Used to de-emphasize button (for example, a "cancel" option), but still show inline with other fields.
 //
 // Styleguide Forms - Buttons
 .button {
@@ -91,7 +91,7 @@
   }
 
   // disabled state
-  &[disabled], &.disabled {
+  &[disabled], &.is-disabled {
     background: $light-gray;
     color: lighten($light-gray, 10%);
     cursor: default;
@@ -106,7 +106,7 @@
     }
   }
 
-  &.-loading {
+  &.is-loading {
     position: relative;
     color: transparent;
     background: #eee neue-asset-url("images/spinner.svg") no-repeat center center;


### PR DESCRIPTION
# Changes
 - Update button state classes to follow naming convention.

__Note:__ Loading styles used to use a pseudo-element, and so did not work on `<input>` elements. This was changed a little ways back when we switched to using SVG for spinners rather than building them using CSS elements.

For review: @DoSomething/front-end 