### PR TITLE
Header spacing fix

### DIFF
--- a/scss/_regions/_header.scss
+++ b/scss/_regions/_header.scss
@@ -176,16 +176,13 @@
     .__date {
       color: #fff;
       font-size: $font-small;
+      margin-top: 0;
       margin-bottom: 9px;
 
       @include media($tablet) {
         font-size: $font-regular;
         float: left;
         margin-bottom: 27px;
-      }
-
-      + .__subtitle {
-        margin-top: -9px;
       }
     }
 

--- a/scss/_regions/_header.scss
+++ b/scss/_regions/_header.scss
@@ -193,12 +193,6 @@
         position: relative;
         width: 50%;
       }
-
-      > .btn, form {
-        @include media($tablet) {
-          float: left;
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
# Changes
 - Fixes header spacing issue by removing top margin on `.__date` element in header.

References DoSomething/dosomething#3844. For review: @DoSomething/front-end 