### PR TITLE
List styles

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -67,7 +67,7 @@ linters:
     extra_properties: []
 
   QualifyingElement:
-    allow_element_with_attribute: true
+    enabled: false
 
   SelectorDepth:
     enabled: false

--- a/js/modernizr/checked.js
+++ b/js/modernizr/checked.js
@@ -3,7 +3,10 @@
  * included in Modernizr until 3.0, so adding manually for now.
  */
 
-Modernizr.addTest('checked', function(){
+/* jshint strict:false */
+/* global Modernizr:false */
+
+Modernizr.addTest("checked", function(){
   return Modernizr.testStyles("#modernizr {position:absolute} #modernizr input {margin-left:10px} #modernizr :checked {margin-left:20px;display:block}", function( elem ){
     var cb = document.createElement("input");
     cb.setAttribute("type", "checkbox");

--- a/js/modernizr/checked.js
+++ b/js/modernizr/checked.js
@@ -4,10 +4,10 @@
  */
 
 Modernizr.addTest('checked', function(){
-  return Modernizr.testStyles('#modernizr {position:absolute} #modernizr input {margin-left:10px} #modernizr :checked {margin-left:20px;display:block}', function( elem ){
-    var cb = document.createElement('input');
-    cb.setAttribute('type', 'checkbox');
-    cb.setAttribute('checked', 'checked');
+  return Modernizr.testStyles("#modernizr {position:absolute} #modernizr input {margin-left:10px} #modernizr :checked {margin-left:20px;display:block}", function( elem ){
+    var cb = document.createElement("input");
+    cb.setAttribute("type", "checkbox");
+    cb.setAttribute("checked", "checked");
     elem.appendChild(cb);
     return cb.offsetLeft === 20;
   });

--- a/js/modernizr/label-click.js
+++ b/js/modernizr/label-click.js
@@ -5,6 +5,9 @@
  * expected behavior still functions.
  */
 
+/* jshint strict:false */
+/* global Modernizr:false */
+
 Modernizr.addTest("label-click", function() {
   var testLabel = document.createElement("label");
   var testInput = document.createElement("input");

--- a/js/modernizr/label-click.js
+++ b/js/modernizr/label-click.js
@@ -5,7 +5,7 @@
  * expected behavior still functions.
  */
 
-Modernizr.addTest('label-click', function() {
+Modernizr.addTest("label-click", function() {
   var testLabel = document.createElement("label");
   var testInput = document.createElement("input");
   testInput.setAttribute("type", "checkbox");

--- a/scss/_base/_typography.scss
+++ b/scss/_base/_typography.scss
@@ -94,7 +94,7 @@ h4, h5, h6, .heading.-delta {
 // List of items. You can use the `.with-lists` class to apply list styles to all `ol` and `ul`
 // within a container, for example when styling Markdown content.
 //
-// .-cozy         - Closely spaced list elements.
+// .-compacted - Closely spaced list elements.
 //
 // Styleguide Typography - Lists
 .list {
@@ -104,7 +104,7 @@ h4, h5, h6, .heading.-delta {
     margin-top: ($base-spacing / 2);
   }
 
-  &.-cozy {
+  &.-compacted {
     li + li {
       margin-top: 0;
     }
@@ -136,7 +136,7 @@ ol.list {
     margin-top: ($base-spacing / 2);
   }
 
-  &.-cozy {
+  &.-compacted {
     li + li {
       margin-top: 0;
     }

--- a/scss/_base/_typography.scss
+++ b/scss/_base/_typography.scss
@@ -91,25 +91,58 @@ h4, h5, h6, .heading.-delta {
   font-weight: $weight-sbold;
 }
 
-// List of items with no ordering.
+// List of items. You can use the `.with-lists` class to apply list styles to all `ol` and `ul`
+// within a container, for example when styling Markdown content.
 //
-// Styleguide Typography - Unordered Lists
-ul {
+// .-cozy         - Closely spaced list elements.
+//
+// Styleguide Typography - Lists
+.list {
+  padding-left: $base-spacing;
+
+  li + li {
+    margin-top: ($base-spacing / 2);
+  }
+
+  &.-cozy {
+    li + li {
+      margin-top: 0;
+    }
+  }
+}
+
+ul.list {
   list-style-type: square;
-  padding-left: $base-spacing;
 }
 
-// List of items with numerical ordering.
-//
-// Styleguide Typography - Ordered Lists
-ol {
+ol.list {
   list-style-type: decimal;
-  padding-left: $base-spacing;
 }
 
-li + li {
-  margin-top: $base-spacing;
+.with-lists {
+  ul, ol {
+    padding-left: $base-spacing;
+  }
+
+  ul {
+    list-style-type: square;
+  }
+
+  ol {
+    list-style-type: decimal;
+  }
+
+  li + li {
+    margin-top: ($base-spacing / 2);
+  }
+
+  &.-cozy {
+    li + li {
+      margin-top: 0;
+    }
+  }
 }
+
 
 // Inline text elements.
 //

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -103,23 +103,25 @@
     <h4 class="heading $modifier_class"><span>Heading</span></h4>
   <% end %>
 
-  <% styleguide_block  'Typography - Unordered Lists' do %>
-    <ul>
-      <li>Norway</li>
-      <li>Sweden</li>
-      <li>Finland</li>
+  <% styleguide_block  'Typography - Lists' do %>
+    <p>An unordered list:</p>
+    <ul class="list $modifier_class">
+      <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In non pretium risus. Sed ultrices dolor magna, in ultricies sapien ornare ac.</li>
+      <li>Curabitur sed odio aliquet, efficitur diam vel, laoreet ipsum. Curabitur faucibus tincidunt augue.</li>
+      <li>In non pretium risus. Sed ultrices dolor magna, in ultricies sapien ornare ac.</li>
     </ul>
-  <% end %>
 
-  <% styleguide_block  'Typography - Ordered Lists' do %>
-    <ol>
-      <li>Norway</li>
-      <li>Sweden</li>
-      <li>Finland</li>
+
+    <p>And an ordered list:</p>
+    <ol class="list $modifier_class">
+      <li>Know it.</li>
+      <li>Plan it.</li>
+      <li>???</li>
+      <li>Profit.</li>
     </ol>
   <% end %>
 
-    <% styleguide_block  'Typography - Inline Elements' do %>
+  <% styleguide_block  'Typography - Inline Elements' do %>
       <p>Lorem <em>italic</em> dolor <mark>important</mark> amet.
     This is some <strong>bold</strong> text, a <a href="#">link</a>, and a <a href="#" class="secondary">secondary link</a>. Also, <code>code(0);</code>.</p>
   <% end %>


### PR DESCRIPTION
# Changes
 - Add `.list` and `.with-lists` (for CMS content) components. This means that lists are now un-styled by default again, and must either be in a `.with-lists` container or specifically styled to be a list. Great!
 - Fixes a few linting issues, and disables the "qualifying element" linter since SCSS-Lint doesn't give us line-by-line ignores. This is still a rule we want to ensure we follow manually.

# Screenshot
![screen shot 2015-01-30 at 1 08 25 pm](https://cloud.githubusercontent.com/assets/583202/5980695/1c503d8c-a881-11e4-872a-f78a459dc566.png)
