### PR TITLE
CTA bugfixes.

### DIFF
--- a/scss/_modules/_cta.scss
+++ b/scss/_modules/_cta.scss
@@ -6,13 +6,12 @@
 
 .cta {
   @include clearfix;
-  @include span(100%);
+  @include gutters;
   background: lighten($light-gray, 10%);
   border-bottom: 2px solid $light-gray;
   border-top: 2px solid $light-gray;
 
   > .wrapper {
-    width: 100%;
     text-align: center;
     padding: $base-spacing 0;
 


### PR DESCRIPTION
# Changes
 - We don't want to accidentally float CTAs, since this can cause display issues if the following element doesn't clear floats. Removes unnecessary width property (CTAs are block elements, so already are 100% width).

For review: @DoSomething/front-end 