### PR TITLE
Form actions

### DIFF
--- a/js/validation.js
+++ b/js/validation.js
@@ -46,7 +46,7 @@ define(function(require) {
    */
   var prepareLabel = function($label) {
     // Check to make sure we haven't already prepared this before
-    if($label.find(".inner-label").length === 0) {
+    if($label.find(".validation").length === 0) {
       var $innerLabel = $("<div class='validation'></div>");
       $innerLabel.append("<div class='validation__label'>" + $label.html() + "</div>");
       $innerLabel.append("<div class='validation__message'></div>");
@@ -151,7 +151,8 @@ define(function(require) {
    */
   var showValidationMessage = function($field, result) {
     var $fieldLabel = $("label[for='" + $field.attr("id") + "']");
-    var $fieldMessage = $fieldLabel.find(".validation__message");
+    var $fieldValidation = $fieldLabel.find(".validation");
+    var $fieldMessage = $fieldValidation.find(".validation__message");
     var fieldLabelHeight = $fieldLabel.height();
     var fieldMessageHeight;
 
@@ -161,7 +162,7 @@ define(function(require) {
     // Highlight/animate field
     if(result.success === true) {
       $field.addClass("-success");
-      $fieldMessage.addClass("success");
+      $fieldMessage.addClass("-success");
     } else {
       $field.addClass("-error");
       $fieldMessage.addClass("-error");
@@ -194,7 +195,7 @@ define(function(require) {
     }
 
     // Animate in the validation message
-    $fieldMessage.addClass("is-showing-message");
+    $fieldValidation.addClass("is-showing-message");
 
     $(".js-mailcheck-fix").on("click", function(e) {
       e.preventDefault();
@@ -210,7 +211,7 @@ define(function(require) {
 
     $field.on("focus", function() {
       $field.removeClass("-warning -error -success shake");
-      $fieldMessage.removeClass("is-showing-message");
+      $fieldValidation.removeClass("is-showing-message");
       $fieldLabel.css("height", "");
     });
 

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -12,16 +12,13 @@
   }
 
   &.-inline {
-    .field-label {
+    .form-label {
       display: inline-block;
       width: auto;
       margin: ($base-spacing / 2) ($base-spacing /2) ($base-spacing / 2) 0;
     }
 
-    input[type="email"], input[type="number"], input[type="password"], input[type="search"],
-    input[type="tel"], input[type="text"], input[type="url"], input[type="color"],
-    input[type="date"], input[type="datetime"], input[type="datetime-local"], input[type="month"],
-    input[type="time"], input[type="week"], textarea {
+    .text-field {
       width: auto;
     }
 
@@ -50,6 +47,7 @@
 // Styleguide Forms - Form Actions
 .form-actions {
   text-align: center;
+  padding-top: ($base-spacing / 2);
 
   &.-padded {
     padding: $base-spacing 0;
@@ -67,7 +65,6 @@
 //
 // Styleguide Forms - Inline Form Actions
 .form-actions.-inline {
-  display: table;
 
   li {
     display: table-cell;
@@ -133,10 +130,7 @@
 // .-error        - Error styling, used for validation issues.
 //
 // Styleguide Forms - Text Input Fields
-input[type="email"], input[type="number"], input[type="password"], input[type="search"],
-input[type="tel"], input[type="text"], input[type="url"], input[type="color"],
-input[type="date"], input[type="datetime"], input[type="datetime-local"], input[type="month"],
-input[type="time"], input[type="week"], textarea {
+.text-field {
   width: 100%;
   font-family: $font-proxima-nova;
   font-size: $font-regular;
@@ -170,7 +164,7 @@ input[type="time"], input[type="week"], textarea {
 // .loading - Indicates search field is loading results.
 //
 // Styleguide Forms - Search Fields
-input[type="search"] {
+.text-field.-search {
   padding-left: 32px;
   background: #fff no-repeat 12px 50%;
   background-image: neue-asset-url("images/search.svg");
@@ -194,13 +188,8 @@ input[type="search"] {
 // Multi-line textarea fields.
 //
 // Styleguide Forms - Text Area Fields
-textarea {
+textarea.text-field {
   resize: vertical;
-}
-
-// Ensure text wraps to new lines when in an <input> button
-input[type="submit"] {
-  white-space: normal;
 }
 
 

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -67,9 +67,7 @@
 //
 // Styleguide Forms - Inline Form Actions
 .form-actions.-inline {
-  ul {
-    display: table;
-  }
+  display: table;
 
   li {
     display: table-cell;

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -12,7 +12,7 @@
   }
 
   &.-inline {
-    .form-label {
+    .field-label {
       display: inline-block;
       width: auto;
       margin: ($base-spacing / 2) ($base-spacing /2) ($base-spacing / 2) 0;
@@ -84,8 +84,8 @@
 // .-warning    - Warning form validation (not an error, but worth double-checking).
 // .-error      - Something's wrong!
 //
-// Styleguide Forms - Form Labels
-.form-label {
+// Styleguide Forms - Field Labels
+.field-label {
   display: block;
   clear: both;
   width: 100%;

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -43,6 +43,45 @@
   }
 }
 
+// Form actions, such as submit buttons.
+//
+// .-padded - Adds top and bottom padding, for use independent of form items.
+//
+// Styleguide Forms - Form Actions
+.form-actions {
+  text-align: center;
+
+  &.-padded {
+    padding: $base-spacing 0;
+  }
+}
+
+.form-actions + .form-actions {
+  margin-top: $base-spacing;
+}
+
+
+// Inline form actions, with all items shown in a row.
+//
+// .-padded - Adds top and bottom padding, for use independent of form items.
+//
+// Styleguide Forms - Inline Form Actions
+.form-actions.-inline {
+  ul {
+    display: table;
+  }
+
+  li {
+    display: table-cell;
+    vertical-align: middle;
+  }
+
+  li + li {
+    padding-left: $base-spacing;
+  }
+
+}
+
 
 // Labels for form elements. Optional validation styles triggered by client-side validation.
 //

--- a/scss/_base/_forms.scss
+++ b/scss/_base/_forms.scss
@@ -3,8 +3,8 @@
 // .-padded - Adds extra padding above and below field group.
 // .-inline - Form elements appear side-by-side.
 //
-// Styleguide Forms - Field Groups
-.field-group {
+// Styleguide Forms - Form Items
+.form-item {
   margin-bottom: ($base-spacing / 2);
 
   &.-padded {
@@ -50,8 +50,8 @@
 // .-warning    - Warning form validation (not an error, but worth double-checking).
 // .-error      - Something's wrong!
 //
-// Styleguide Forms - Field Labels
-.field-label {
+// Styleguide Forms - Form Labels
+.form-label {
   display: block;
   clear: both;
   width: 100%;

--- a/scss/_components/_button.scss
+++ b/scss/_components/_button.scss
@@ -15,7 +15,7 @@
   clear: both;
   background: $blue;
   border: 0;
-  margin: 4px 0;
+  margin: 0;
   line-height: 1.3;
   padding: 0.55em 1em 0.45em;
   cursor: pointer;
@@ -28,7 +28,13 @@
   text-transform: uppercase;
   text-shadow: none;
   border-radius: $lg-border-radius;
+
+  // Fixes styling in Firefox/Safari; non-standard properties so not autoprefixed.
+  -moz-appearance: none;
   -webkit-appearance: none;
+
+  // Ensure text wraps to new lines when in an <input> button
+  white-space: normal;
 
   &:hover {
     background: lighten($blue, $color-tint);
@@ -135,3 +141,4 @@
     }
   }
 }
+

--- a/scss/_components/_button.scss
+++ b/scss/_components/_button.scss
@@ -9,7 +9,7 @@
 // .-secondary        - Should be used if not the main call-to-action on a page.
 // .-tertiary         - Used to de-emphasize button (for example, a "cancel" option), but still show inline with other fields.
 //
-// Styleguide Forms - Buttons
+// Styleguide Button
 .button {
   display: inline-block;
   clear: both;

--- a/scss/_regions/_navigation.scss
+++ b/scss/_regions/_navigation.scss
@@ -19,12 +19,15 @@
         text-shadow: $text-shadow;
       }
 
-      input[type="search"] {
+      .text-field {
         color: #fff;
         text-shadow: $text-shadow;
         border: 1px solid #fff;
         box-shadow: 0 1px 3px rgba(#000, 0.2),
-                    inset 0 1px 3px rgba(#000, 0.2);
+        inset 0 1px 3px rgba(#000, 0.2);
+      }
+
+      .text-field.-search {
         background-image: neue-asset-url("images/search_white.svg");
 
         .no-svg & {
@@ -240,32 +243,38 @@
     }
   }
 
-  input[type="search"] {
+  .text-field {
     background-color: transparent;
-    background-image: neue-asset-url("images/search_white.svg");
     color: #fff;
     padding-top: 5px;
     padding-bottom: 5px;
     border: 1px solid #fff;
     box-shadow: 0 1px 0 rgba(#000, 0.2),
-                inset 0 1px 0 rgba(#000, 0.2);
+    inset 0 1px 0 rgba(#000, 0.2);
     transition: width 0.5s;
 
     @include media($tablet) {
       width: 100px;
-      background-image: neue-asset-url("images/search_black.svg");
       color: $off-black;
       border: 1px solid $off-black;
       box-shadow: 0 1px 0 rgba(#fff, 0.2),
-                  inset 0 1px 0 rgba(#fff, 0.2);
-
-      .no-svg & {
-        background-image: neue-asset-url("images/fallbacks/search_black.png");
-      }
+      inset 0 1px 0 rgba(#fff, 0.2);
     }
 
     @include media($large) {
       width: 200px;
+    }
+  }
+
+  .text-field.search {
+    background-image: neue-asset-url("images/search_white.svg");
+
+    @include media($tablet) {
+      background-image: neue-asset-url("images/search_black.svg");
+
+      .no-svg & {
+        background-image: neue-asset-url("images/fallbacks/search_black.png");
+      }
     }
 
     .no-svg & {

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -218,7 +218,7 @@
     <p>We don't want to re-invent the wheel. Re-usable interface patterns are catalogued within Neue to promote consistency throughout our interfaces and minimize code bloat. We start by defining atomic components. These are the smallest building blocks of our interfaces.</p>
 
     <h4 id="buttons">Buttons</h4>
-    <% styleguide_block  'Forms - Buttons' do %>
+    <% styleguide_block  'Button' do %>
       <a class="button $modifier_class">Example Button</a>
     <% end %>
 

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -129,8 +129,8 @@
   <h3 id="forms">Forms</h3>
   <% styleguide_block  'Forms - Form Items' do %>
     <div class="form-item $modifier_class">
-      <label class="field-label">Form Label</label>
-      <input type="text">
+      <label class="form-label">Form Label</label>
+      <input type="text" class="text-field">
     </div>
   <% end %>
 
@@ -159,19 +159,19 @@
         <div class="validation__message $modifier_class">Label</div>
       </span>
     </label>
-    <input class="$modifier_class" type="text">
+    <input class="text-field $modifier_class" type="text">
   <% end %>
 
   <% styleguide_block  'Forms - Text Input Fields' do %>
-    <input type="text" class="$modifier_class" placeholder="placeholder">
+    <input type="text" class="text-field" placeholder="placeholder">
   <% end %>
 
   <% styleguide_block  'Forms - Search Fields' do %>
-    <input type="search" class="$modifier_class" placeholder="Find something...">
+    <input type="search" class="text-field -search" placeholder="Find something...">
   <% end %>
 
   <% styleguide_block  'Forms - Text Area Fields' do %>
-    <textarea name="textarea" placeholder="Write something here..."></textarea>
+    <textarea name="textarea" class="text-field" placeholder="Write something here..."></textarea>
   <% end %>
 
   <% styleguide_block  'Forms - Select Boxes' do %>
@@ -185,7 +185,7 @@
   <% end %>
 
   <% styleguide_block  'Forms - Option Fields' do %>
-    <h4>Some checkboxes</h4>
+    <label class="form-label">Some checkboxes</label>
     <div class="form-item">
       <label class="option -checkbox">
         <input checked type="checkbox" id="option1">
@@ -206,7 +206,7 @@
       </label>
     </div>
 
-    <h4>Some radio options</h4>
+    <label class="form-label">Some radio buttons</label>
     <div class="form-item">
       <label class="option -radio">
         <input checked type="radio" name="choice" id="choice1">
@@ -774,11 +774,15 @@
     <div data-modal id="modal--pagetwo" role="dialog" data-modal-close="true" data-modal-skip-form="#skip-form">
       <h2 class="heading -banner">Now fill out this form.</h2>
       <form action="#">
-        <label for="name">Name</label>
-        <input type="text" class="js-validate" name="name" id="name" data-validate-trigger="#confirmName">
+        <div class="form-item">
+          <label for="name" class="form-label">Name</label>
+          <input type="text" class="text-field js-validate" name="name" id="name" data-validate-trigger="#confirmName">
+        </div>
 
-        <label for="confirmName">Confirm Name</label>
-        <input type="text" name="confirmName" class="js-validate" data-validate="match" data-validate-match="#name" id="confirmName">
+        <div class="form-item">
+          <label for="confirmName" class="form-label">Confirm Name</label>
+          <input type="text" name="confirmName" class="text-field js-validate" data-validate="match" data-validate-match="#name" id="confirmName">
+        </div>
 
         <div class="form-actions">
           <input type="submit" class="button">

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -134,6 +134,28 @@
     </div>
   <% end %>
 
+  <% styleguide_block  'Forms - Form Actions' do %>
+  <div class="form-actions $modifier_class">
+    <input type="submit" class="button" value="Submit">
+  </div>
+
+  <div class="form-actions $modifier_class">
+    <ul>
+      <li><a href="#">Forgot your password?</a></li>
+      <li><a href="#">Create an account</a></li>
+    </ul>
+  </div>
+  <% end %>
+
+  <% styleguide_block  'Forms - Inline Form Actions' do %>
+  <div class="form-actions -inline $modifier_class">
+    <ul>
+      <li><input type="submit" class="button" value="Submit"></li>
+      <li><input type="submit" class="button -tertiary" value="Skip"></li>
+    </ul>
+  </div>
+  <% end %>
+
   <% styleguide_block  'Forms - Form Labels' do %>
     <!-- validation classes and markup generated dynamically -->
     <label class="form-label">

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -135,25 +135,21 @@
   <% end %>
 
   <% styleguide_block  'Forms - Form Actions' do %>
-  <div class="form-actions $modifier_class">
-    <input type="submit" class="button" value="Submit">
-  </div>
+    <div class="form-actions $modifier_class">
+      <input type="submit" class="button" value="Submit">
+    </div>
 
-  <div class="form-actions $modifier_class">
-    <ul>
+    <ul class="form-actions $modifier_class">
       <li><a href="#">Forgot your password?</a></li>
       <li><a href="#">Create an account</a></li>
     </ul>
-  </div>
   <% end %>
 
   <% styleguide_block  'Forms - Inline Form Actions' do %>
-  <div class="form-actions -inline $modifier_class">
-    <ul>
+    <ul class="form-actions -inline $modifier_class">
       <li><input type="submit" class="button" value="Submit"></li>
       <li><input type="submit" class="button -tertiary" value="Skip"></li>
     </ul>
-  </div>
   <% end %>
 
   <% styleguide_block  'Forms - Form Labels' do %>

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -129,7 +129,7 @@
   <h3 id="forms">Forms</h3>
   <% styleguide_block  'Forms - Form Items' do %>
     <div class="form-item $modifier_class">
-      <label class="form-label">Form Label</label>
+      <label class="field-label">Field Label</label>
       <input type="text" class="text-field">
     </div>
   <% end %>
@@ -152,11 +152,11 @@
     </ul>
   <% end %>
 
-  <% styleguide_block  'Forms - Form Labels' do %>
+  <% styleguide_block  'Forms - Field Labels' do %>
     <!-- validation classes and markup generated dynamically -->
-    <label class="form-label">
+    <label class="field-label">
       <span class="validation">
-        <div class="validation__message $modifier_class">Label</div>
+        <div class="validation__message $modifier_class">Field Label</div>
       </span>
     </label>
     <input class="text-field $modifier_class" type="text">
@@ -185,7 +185,7 @@
   <% end %>
 
   <% styleguide_block  'Forms - Option Fields' do %>
-    <label class="form-label">Some checkboxes</label>
+    <label class="field-label">Some checkboxes</label>
     <div class="form-item">
       <label class="option -checkbox">
         <input checked type="checkbox" id="option1">
@@ -206,7 +206,7 @@
       </label>
     </div>
 
-    <label class="form-label">Some radio buttons</label>
+    <label class="field-label">Some radio buttons</label>
     <div class="form-item">
       <label class="option -radio">
         <input checked type="radio" name="choice" id="choice1">
@@ -775,12 +775,12 @@
       <h2 class="heading -banner">Now fill out this form.</h2>
       <form action="#">
         <div class="form-item">
-          <label for="name" class="form-label">Name</label>
+          <label for="name" class="field-label">Name</label>
           <input type="text" class="text-field js-validate" name="name" id="name" data-validate-trigger="#confirmName">
         </div>
 
         <div class="form-item">
-          <label for="confirmName" class="form-label">Confirm Name</label>
+          <label for="confirmName" class="field-label">Confirm Name</label>
           <input type="text" name="confirmName" class="text-field js-validate" data-validate="match" data-validate-match="#name" id="confirmName">
         </div>
 

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -127,16 +127,16 @@
   <% end %>
 
   <h3 id="forms">Forms</h3>
-  <% styleguide_block  'Forms - Field Groups' do %>
-    <div class="field-group $modifier_class">
+  <% styleguide_block  'Forms - Form Items' do %>
+    <div class="form-item $modifier_class">
       <label class="field-label">Form Label</label>
       <input type="text">
     </div>
   <% end %>
 
-  <% styleguide_block  'Forms - Field Labels' do %>
+  <% styleguide_block  'Forms - Form Labels' do %>
     <!-- validation classes and markup generated dynamically -->
-    <label class="field-label">
+    <label class="form-label">
       <span class="validation">
         <div class="validation__message $modifier_class">Label</div>
       </span>
@@ -168,7 +168,7 @@
 
   <% styleguide_block  'Forms - Option Fields' do %>
     <h4>Some checkboxes</h4>
-    <div class="field-group">
+    <div class="form-item">
       <label class="option -checkbox">
         <input checked type="checkbox" id="option1">
         <span class="option__indicator"></span>
@@ -189,7 +189,7 @@
     </div>
 
     <h4>Some radio options</h4>
-    <div class="field-group">
+    <div class="form-item">
       <label class="option -radio">
         <input checked type="radio" name="choice" id="choice1">
         <span class="option__indicator"></span>


### PR DESCRIPTION
# Changes
 - Renames `.field-group` to `.form-item`. Computer Science.
 - Adds "Form Actions" pattern, with padded and inline modifiers.
 - Adds "Text Field" pattern (`.text-field`) to style text fields, rather than trying to target all potential HTML5 input types. This also makes text field styles "opt-in" like other form components.
 - Fixes incorrect selectors in validation script, based on changes to markup in #413.

For review: @DoSomething/front-end 

# Screenshots & Markup Examples
![screen shot 2015-02-02 at 1 12 38 pm](https://cloud.githubusercontent.com/assets/583202/6006048/5f2323aa-aadd-11e4-9cd4-baf006d50c83.png)

![screen shot 2015-02-02 at 1 11 37 pm](https://cloud.githubusercontent.com/assets/583202/6006053/630f900c-aadd-11e4-9931-9b4bf6a3ca1b.png)

__Note:__ They're both the same "pattern" and very similar markup, but I split them out in the style guide since the usage is different and so the same content would not really work well to demonstrate both.