### PR TITLE
Add "concatenated" modifier for with-lists.

### DIFF
--- a/scss/_base/_typography.scss
+++ b/scss/_base/_typography.scss
@@ -141,6 +141,12 @@ ol.list {
       margin-top: 0;
     }
   }
+
+  &.-concatenated {
+    ul + ul {
+      margin-top: 0;
+    }
+  }
 }
 
 


### PR DESCRIPTION
# Changes
 - Adds a `-concatenated` modifier for the `with-lists` class. This removes spacing between `ul` elements inside that wrapper, and is necessary for the funky markup on the campaigns page.

For review: @DoSomething/front-end 