### PR TITLE
Modernizr build filename

### DIFF
--- a/styleguide/layout.erb
+++ b/styleguide/layout.erb
@@ -8,7 +8,7 @@
   <meta charset="utf-8">
   <title>Pattern Library | DoSomething.org</title>
 
-  <script type="text/javascript" src="dist/modernizr-neue.js"></script>
+  <script type="text/javascript" src="dist/modernizr.js"></script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">

--- a/tasks/modernizr.js
+++ b/tasks/modernizr.js
@@ -1,7 +1,7 @@
 module.exports = {
   all: {
     "devFile": "remote",
-    "outputFile": "dist/modernizr-neue.js",
+    "outputFile": "dist/modernizr.js",
     "files" : {
       "src": [
         "js/**/*.js",


### PR DESCRIPTION
# Changes
 - Clean up Modernizr build filename. Corresponds with updated README instructions in #431.

For review: @DoSomething/front-end 