### PR TITLE
Modal mini-refactor

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -12,7 +12,7 @@ define(function() {
     $(".js-navigation-toggle").on("touchstart mousedown", function(e) {
       e.preventDefault();
 
-      $(".chrome").toggleClass("mobile-menu-open");
+      $(".chrome").toggleClass("has-mobile-menu");
       $(".navigation").toggleClass("is-visible");
     });
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -134,6 +134,7 @@ define(function(require) {
 
     // Remove overlay and reset scroll position
     $chrome.removeClass("has-modal");
+    $chrome.removeClass("animated-close");
     $chrome.css("top", "");
     $document.scrollTop(scrollOffset);
 
@@ -152,6 +153,7 @@ define(function(require) {
     var scrollOffset = parseInt($chrome.css("top")) * -1;
 
     if(options.animated && Modernizr.cssanimations) {
+      $chrome.addClass("animated-close");
       $modalContainer.addClass("animated-close");
       $modalContainer.one("webkitAnimationEnd oanimationend msAnimationEnd animationend", function() {
         _cleanup(scrollOffset);

--- a/js/modal.js
+++ b/js/modal.js
@@ -98,7 +98,7 @@ define(function(require) {
     if(!isOpen()) {
       // Set up overlay and show modal
       $chrome.css("top", offsetTop);
-      $chrome.addClass("modal-open");
+      $chrome.addClass("has-modal");
       $modalContainer.css("display", "block");
       if(options.animated && Modernizr.cssanimations) {
         $modalContainer.addClass("animated-open");
@@ -133,7 +133,7 @@ define(function(require) {
     $modal.find(".js-modal-generated").remove();
 
     // Remove overlay and reset scroll position
-    $chrome.removeClass("modal-open");
+    $chrome.removeClass("has-modal");
     $chrome.css("top", "");
     $document.scrollTop(scrollOffset);
 

--- a/scss/_regions/_chrome.scss
+++ b/scss/_regions/_chrome.scss
@@ -17,9 +17,9 @@
     @include container(16);
   }
 
-  // See also: _modal.scss (.chrome.modal-open)
+  // See also: _modal.scss (.chrome.has-modal)
 
-  // See also: _chrome.scss (.chrome.mobile-menu-open)
+  // See also: _navigation.scss (.chrome.has-mobile-menu)
 }
 
 

--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -115,6 +115,7 @@
     background-image: neue-asset-url("images/fallbacks/ie8-rgba-black-50.png");
     background: rgba(0, 0, 0, 0.5);
     animation: fadeIn 0.25s;
+    z-index: 9998;
   }
 
   &.animated-close:after {

--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -34,7 +34,7 @@
 [data-modal] {
   position: relative;
   background: #fff;
-  box-shadow: 0 0 100px rgba(0, 0, 0, 0.75);
+  box-shadow: 0 0 60px rgba(0, 0, 0, 0.75);
   width: auto;
   word-wrap: break-word;
   z-index: 1050;

--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -99,6 +99,7 @@
   display: none;
 }
 
-.chrome.modal-open {
+// See also: _chrome.scss
+.chrome.has-modal {
   position: fixed;
 }

--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -1,4 +1,8 @@
-// Show supplementary information to a user without leaving the page. Fills screen on mobile, centered with overlay on tablet/desktop.
+// Show supplementary information to a user without leaving the page. Fills
+// screen on mobile, centered with overlay on tablet/desktop. Use `.modal__block`
+// element to add padding inside the modal. (This allows "full-width" modal content
+// to work without a negative margin.)
+//
 // #### Options:
 // - `[data-modal-close]`: set to "true" to include a close button on the modal, or "skip" to delegate a skip form action
 // - `[data-modal-skip-form]`: selector for a skip `form` element to submit upon clicking the "skip" link
@@ -38,8 +42,6 @@
   background: #fff;
   box-shadow: 0 0 100px rgba(0, 0, 0, 0.75);
   width: auto;
-  padding: $base-spacing;
-  margin: 0;
   word-wrap: break-word;
   z-index: 1050;
 
@@ -53,7 +55,6 @@
     // make space for "x" button & fit banner to edge of modal
     padding-left: $base-spacing;
     padding-right: 72px;
-    margin: (-$base-spacing) (-$base-spacing) $base-spacing;
   }
 }
 
@@ -90,6 +91,13 @@
       text-decoration: underline;
     }
   }
+}
+
+
+// Modal content block
+// Adds proper spacing around content in modal.
+.modal__block {
+  padding: $base-spacing;
 }
 
 

--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -16,16 +16,10 @@
   left: 0;
   right: 0;
   min-height: 100%;
-  background-image: neue-asset-url("images/fallbacks/ie8-rgba-black-50.png");
-  background: rgba(0, 0, 0, 0.5);
   z-index: 9999;
 
   @include media($tablet) {
     padding: 72px;
-  }
-
-  &.animated-open {
-    animation: fadeIn 0.25s;
   }
 
   &.animated-close {
@@ -110,4 +104,20 @@
 // See also: _chrome.scss
 .chrome.has-modal {
   position: fixed;
+
+  &:after {
+    content: "";
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-image: neue-asset-url("images/fallbacks/ie8-rgba-black-50.png");
+    background: rgba(0, 0, 0, 0.5);
+    animation: fadeIn 0.25s;
+  }
+
+  &.animated-close:after {
+    animation: fadeOut 0.25s;
+  }
 }

--- a/scss/_regions/_navigation.scss
+++ b/scss/_regions/_navigation.scss
@@ -311,7 +311,8 @@
 }
 
 // When menu is open, prevent scrolling on mobile breakpoint.
-.chrome.mobile-menu-open {
+// See also: _chrome.scss
+.chrome.has-mobile-menu {
   @include media($mobile) {
     position: fixed;
   }

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -766,34 +766,38 @@
 
     <div data-modal id="modal--example" role="dialog">
       <h2 class="heading -banner">Example Content</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem, officia impedit eius velit consectetur provident ullam! Incidunt, rem, maxime sit non natus praesentium nobis voluptas enim repudiandae. Commodi, eum, accusamus. Let us take a look at <a href="#" data-modal-href="#modal--pagetwo">another modal</a>.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem, officia impedit eius velit consectetur provident ullam! Incidunt, rem, maxime sit non natus praesentium nobis voluptas enim repudiandae. Commodi, eum, accusamus.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem, officia impedit eius velit consectetur provident ullam! Incidunt, rem, maxime sit non natus praesentium nobis voluptas enim repudiandae. Commodi, eum, accusamus. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem, officia impedit eius velit consectetur provident ullam! Incidunt, rem, maxime sit non natus praesentium nobis voluptas enim repudiandae. Commodi, eum, accusamus.</p>
+      <div class="modal__block">
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem, officia impedit eius velit consectetur provident ullam! Incidunt, rem, maxime sit non natus praesentium nobis voluptas enim repudiandae. Commodi, eum, accusamus. Let us take a look at <a href="#" data-modal-href="#modal--pagetwo">another modal</a>.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem, officia impedit eius velit consectetur provident ullam! Incidunt, rem, maxime sit non natus praesentium nobis voluptas enim repudiandae. Commodi, eum, accusamus.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem, officia impedit eius velit consectetur provident ullam! Incidunt, rem, maxime sit non natus praesentium nobis voluptas enim repudiandae. Commodi, eum, accusamus. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem, officia impedit eius velit consectetur provident ullam! Incidunt, rem, maxime sit non natus praesentium nobis voluptas enim repudiandae. Commodi, eum, accusamus.</p>
+      </div>
     </div>
 
     <div data-modal id="modal--pagetwo" role="dialog" data-modal-close="true" data-modal-skip-form="#skip-form">
       <h2 class="heading -banner">Now fill out this form.</h2>
-      <form action="#">
-        <div class="form-item">
-          <label for="name" class="field-label">Name</label>
-          <input type="text" class="text-field js-validate" name="name" id="name" data-validate-trigger="#confirmName">
-        </div>
+      <div class="modal__block">
+        <form action="#">
+          <div class="form-item">
+            <label for="name" class="field-label">Name</label>
+            <input type="text" class="text-field js-validate" name="name" id="name" data-validate-trigger="#confirmName">
+          </div>
 
-        <div class="form-item">
-          <label for="confirmName" class="field-label">Confirm Name</label>
-          <input type="text" name="confirmName" class="text-field js-validate" data-validate="match" data-validate-match="#name" id="confirmName">
-        </div>
+          <div class="form-item">
+            <label for="confirmName" class="field-label">Confirm Name</label>
+            <input type="text" name="confirmName" class="text-field js-validate" data-validate="match" data-validate-match="#name" id="confirmName">
+          </div>
 
-        <div class="form-actions">
-          <input type="submit" class="button">
-        </div>
-      </form>
+          <div class="form-actions">
+            <input type="submit" class="button">
+          </div>
+        </form>
 
-      <form action="http://www.google.com" id="skip-form">
-        <div class="form-actions">
-          <input type="submit" value="Skip" class="button -tertiary">
-        </div>
-      </form>
+        <form action="http://www.google.com" id="skip-form">
+          <div class="form-actions">
+            <input type="submit" value="Skip" class="button -tertiary">
+          </div>
+        </form>
+      </div>
     </div>
   <% end %>
 


### PR DESCRIPTION
# Changes
- Adds `.modal__block` element for adding padding in modals. This allows "full-width" modal content to work without a negative margin, and follows the same convention we use for container pattern.
- Attach overlay to the chrome, rather than the modal container, so it doesn't scroll on Safari/iOS. This makes rubber-band scrolling look way better.
- Refactors chrome modifiers (for mobile-menu and modals) to use standard state naming scheme.

For review: @DoSomething/front-end 