### PR TITLE
Add Android browser to Autoprefixer browsers array.

### DIFF
--- a/tasks/postcss.js
+++ b/tasks/postcss.js
@@ -5,7 +5,7 @@ module.exports = {
       map: false,
       processors: [
         require('autoprefixer-core')({
-          browsers: ['last 4 versions', 'Firefox ESR', 'Opera 12.1']
+          browsers: ['last 4 versions', 'Firefox ESR', 'Opera 12.1', 'Android >= 4']
         }).postcss,
         require('css-mqpacker').postcss
       ]


### PR DESCRIPTION
# Changes
 - Add Android browser to Autoprefixer browsers array. This ensures prefixes needed for Android browser are added. This fixes an issue where CSS Gradients would not appear on Android stock browser.

For review: @DoSomething/front-end 