### PR TITLE
Fix display of markdown content in Footnote lists.

### DIFF
--- a/scss/_components/_footnote.scss
+++ b/scss/_components/_footnote.scss
@@ -23,6 +23,10 @@
     text-align: right;
   }
 
+  li p {
+    display: inline-block;
+  }
+
   a {
     color: $med-gray;
     text-decoration: underline;


### PR DESCRIPTION
# Changes
 - Display paragraphs in Footnote lists as inline-block elements. Fixes issues with Markdown source content.

For review: @DoSomething/front-end 