### PR TITLE
Restore proper fallback gradient for IE8 and IE9.

### DIFF
--- a/scss/_regions/_header.scss
+++ b/scss/_regions/_header.scss
@@ -146,6 +146,10 @@
       @include media($tablet) {
         background: linear-gradient(rgba(#000, 0) 40%, rgba(#000, 0.2) 70%, rgba(#000, 0.5) 87%, rgba(#000, 0.85) 100%);
       }
+
+      .modernizr-no-cssgradients & {
+        background: transparent neue-asset-url("images/fallbacks/black-gradient.png") 0 bottom repeat-x;
+      }
     }
 
     > .wrapper {


### PR DESCRIPTION
# Changes
 - Restore proper fallback gradient for IE8 and IE9.

For review: @DoSomething/front-end 

![who did this](http://bukk.it/whodidthis.jpg)