### PR TITLE
Re-order mosaic and featured patterns to override correctly.

### DIFF
--- a/scss/_modules/_gallery.scss
+++ b/scss/_modules/_gallery.scss
@@ -83,27 +83,6 @@
     }
   }
 
-  // Removes spacing between gallery items. This is typically used with our __Tile__ pattern.
-  //
-  // Styleguide Gallery - Mosaic
-  &.-mosaic {
-    > li {
-      margin: 0;
-      padding: 0;
-
-      // Ensure that media-queried grid spacing from other patterns doesn't override.
-      &:first-child {
-        @include media($tablet) {
-          padding: 0;
-        }
-      }
-
-      @include media($tablet) {
-        padding: 0;
-      }
-    }
-  }
-
   // Gallery style which emphasizes the first item in the gallery.
   // Works best when paired with the gallery's `-quartet` and `-mosaic` modifier classes.
   //
@@ -127,5 +106,27 @@
       }
     }
   }
+
+  // Removes spacing between gallery items. This is typically used with our __Tile__ pattern.
+  //
+  // Styleguide Gallery - Mosaic
+  &.-mosaic {
+    > li {
+      margin: 0;
+      padding: 0;
+
+      // Ensure that media-queried grid spacing from other patterns doesn't override.
+      &:first-child {
+        @include media($tablet) {
+          padding: 0;
+        }
+      }
+
+      @include media($tablet) {
+        padding: 0;
+      }
+    }
+  }
+
 }
 

--- a/styleguide/index.erb
+++ b/styleguide/index.erb
@@ -533,51 +533,6 @@
     </ul>
     <% end %>
 
-    <% styleguide_block  'Gallery - Mosaic' do %>
-    <ul class="gallery -quartet -mosaic">
-      <li>
-        <article class="tile">
-          <a class="wrapper" href="#">
-            <div class="tile__meta">
-              <h1 class="tile__title">Kitten Overlord</h1>
-            </div>
-            <img alt="kitten overlords" src="http://placekitten.com/g/300/300" />
-          </a>
-        </article>
-      </li>
-      <li>
-        <article class="tile">
-          <a class="wrapper" href="#">
-            <div class="tile__meta">
-              <h1 class="tile__title">Kitten Overlord</h1>
-            </div>
-            <img alt="kitten overlords" src="http://placekitten.com/g/300/300" />
-          </a>
-        </article>
-      </li>
-      <li>
-        <article class="tile">
-          <a class="wrapper" href="#">
-            <div class="tile__meta">
-              <h1 class="tile__title">Kitten Overlord</h1>
-            </div>
-            <img alt="kitten overlords" src="http://placekitten.com/g/300/300" />
-          </a>
-        </article>
-      </li>
-      <li>
-        <article class="tile">
-          <a class="wrapper" href="#">
-            <div class="tile__meta">
-              <h1 class="tile__title">Kitten Overlord</h1>
-            </div>
-            <img alt="kitten overlords" src="http://placekitten.com/g/300/300" />
-          </a>
-        </article>
-      </li>
-    </ul>
-    <% end %>
-
     <% styleguide_block  'Gallery - Featured' do %>
     <ul class="gallery -quartet -mosaic -featured">
       <li>
@@ -630,6 +585,51 @@
           </a>
         </article>
       </li>
+    </ul>
+    <% end %>
+
+    <% styleguide_block  'Gallery - Mosaic' do %>
+    <ul class="gallery -quartet -mosaic">
+        <li>
+            <article class="tile">
+                <a class="wrapper" href="#">
+                    <div class="tile__meta">
+                        <h1 class="tile__title">Kitten Overlord</h1>
+                    </div>
+                    <img alt="kitten overlords" src="http://placekitten.com/g/300/300" />
+                </a>
+            </article>
+        </li>
+        <li>
+            <article class="tile">
+                <a class="wrapper" href="#">
+                    <div class="tile__meta">
+                        <h1 class="tile__title">Kitten Overlord</h1>
+                    </div>
+                    <img alt="kitten overlords" src="http://placekitten.com/g/300/300" />
+                </a>
+            </article>
+        </li>
+        <li>
+            <article class="tile">
+                <a class="wrapper" href="#">
+                    <div class="tile__meta">
+                        <h1 class="tile__title">Kitten Overlord</h1>
+                    </div>
+                    <img alt="kitten overlords" src="http://placekitten.com/g/300/300" />
+                </a>
+            </article>
+        </li>
+        <li>
+            <article class="tile">
+                <a class="wrapper" href="#">
+                    <div class="tile__meta">
+                        <h1 class="tile__title">Kitten Overlord</h1>
+                    </div>
+                    <img alt="kitten overlords" src="http://placekitten.com/g/300/300" />
+                </a>
+            </article>
+        </li>
     </ul>
     <% end %>
   </div>


### PR DESCRIPTION
# Changes
 - When "mosaic" and "featured" are both applied to a gallery, the first block should not gain padding from the `-featured` modifier.

For review: @DoSomething/front-end 