### PR TITLE
Configure builds to run through Wercker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-- 2.1.1
-before_script:
-- npm install grunt-cli -g
-- npm install
-script:
-- grunt test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Neue [![Build Status](http://img.shields.io/travis/DoSomething/neue/dev.svg?style=flat)](https://travis-ci.org/DoSomething/neue) 
+# Neue [![Build Status](http://img.shields.io/wercker/ci/550b2c5b67ccfc73272e2f42.svg)](https://travis-ci.org/DoSomething/neue) 
 This is [Neue](http://neue.dosomething.org), our interface framework and pattern library. It defines a set of base styles and common patterns shared throughout our website. It's a strong foundation for building beautiful interfaces.
 
 Neue was built for our internal needs at DoSomething.org, but it could also work for your organization. Feel free to fork this repository and use it as a starting point for your own website and style guide, or read more about [why we open-source our code](https://blog.dosomething.org/we-open-sourced-our-code-heres-why-you-should-too/).

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "start": "node styleguide/bin/start.js",
+    "test": "grunt test",
     "postinstall": "bower install"
   },
   "repository": {

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,9 @@
+box: wercker/nodejs
+
+# Run tests on all pull requests and branches
+build:
+  steps:
+    - npm-install
+    - grunt:
+        tasks: build
+    - npm-test


### PR DESCRIPTION
# Changes
 - Switch CI builds to Wercker because it's a billion times faster (and we're already using it for CI on a lot of other projects). :traffic_light: 

For review: @DoSomething/front-end 

# Scientific Measurement
![screen shot 2015-03-19 at 4 21 28 pm](https://cloud.githubusercontent.com/assets/583202/6740125/0bf58e62-ce54-11e4-9f89-a364f556a48e.png)


(Two Wercker builds have completed, while we're still waiting for the first Travis build to start...)


