### PR TITLE
Watch task should run debug compilation tasks.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -208,7 +208,7 @@ module.exports = function(grunt) {
     watch: {
       sass: {
         files: ["scss/**/*.scss"],
-        tasks: ["sass", "postcss"]
+        tasks: ["sass:debug", "postcss:debug"]
       },
       js: {
         files: ["js/**/*.js"],


### PR DESCRIPTION
# Changes
 - Watch task should run debug compilation tasks. (Was accidentally running multitask, so was compiling for dev and overwriting with a second compilation with prod settings.)

:cactus: 