### PR TITLE
Fix header on "Messages" pattern.

### DIFF
--- a/scss/_components/_messages.scss
+++ b/scss/_components/_messages.scss
@@ -1,3 +1,5 @@
+// Messages
+//
 // Status message styles. These should be used to provide feedback to the user for
 // events that occur outside the normal application flow (such as application errors).
 // Close button is added using JavaScript. See `system-messages.js`.


### PR DESCRIPTION
# Changes
 - Fixes header on "Messages" pattern. Was previously parsing the whole description block as the header and placing it in a `h4`. Gross.

:cactus: 