### PR TITLE
Forms (experimental)

### DIFF
--- a/scss/_components/_forms/_button.scss
+++ b/scss/_components/_forms/_button.scss
@@ -32,7 +32,7 @@
   text-decoration: none;
   text-transform: uppercase;
   text-shadow: none;
-  border-radius: $lg-border-radius;
+  border-radius: $sm-border-radius;
 
   // Fixes styling in Firefox/Safari; non-standard properties so not autoprefixed.
   -moz-appearance: none;

--- a/scss/_components/_forms/_field-label.scss
+++ b/scss/_components/_forms/_field-label.scss
@@ -23,6 +23,7 @@
   font-size: 16px;
   font-weight: 600;
   margin: 0 0 ($base-spacing / 4);
+  padding-left: ($base-spacing / 4);
   height: 1.5em;
   overflow: hidden;
   transition: height 0.5s;

--- a/scss/_components/_forms/_field-label.scss
+++ b/scss/_components/_forms/_field-label.scss
@@ -22,8 +22,7 @@
   width: 100%;
   font-size: 16px;
   font-weight: 600;
-  margin: 0 0 ($base-spacing / 4);
-  padding-left: ($base-spacing / 4);
+  margin: 0;
   height: 1.5em;
   overflow: hidden;
   transition: height 0.5s;

--- a/scss/_components/_forms/_form-item.scss
+++ b/scss/_components/_forms/_form-item.scss
@@ -13,7 +13,7 @@
 //
 // Styleguide Forms - Form Item
 .form-item {
-  margin-bottom: ($base-spacing / 2);
+  margin-bottom: $base-spacing;
 
   &.-padded {
     margin: $base-spacing 0;

--- a/scss/_components/_forms/_text-field.scss
+++ b/scss/_components/_forms/_text-field.scss
@@ -8,20 +8,25 @@
 // .has-error     - Error state, used for validation issues.
 //
 // Markup:
+//   <label class="field-label">First Name</label>
 //   <input type="text" class="text-field {{modifier_class}}" placeholder="Type something...">
 //
 // Styleguide Forms - Text Field
 .text-field {
   width: 100%;
-  font-family: $font-proxima-nova;
-  font-size: $font-regular;
-  border: 1px solid $light-gray;
-  border: 1px solid rgba(0, 0, 0, 0.14);
-  border-radius: $lg-border-radius;
+  font-family: $font-handwritten;
+  font-size: $font-medium;
+  border: 0;
+  border-bottom: 2px solid $med-gray;
   background-clip: padding-box;
-  padding: ($base-spacing / 2);
+  padding: 0 ($base-spacing / 4);
   margin: 0;
   transition: border 0.5s;
+
+  &::-webkit-input-placeholder { font-family: $font-proxima-nova; font-size: $font-regular; color: $light-gray; line-height: 1.8; }
+  &::-moz-placeholder { font-family: $font-proxima-nova;  font-size: $font-regular;color: $light-gray; line-height: 1.8; }
+  &:-moz-placeholder { font-family: $font-proxima-nova; font-size: $font-regular; color: $light-gray; line-height: 1.8; }
+  &:-ms-input-placeholder { font-family: $font-proxima-nova; font-size: $font-regular; color: $light-gray; line-height: 1.8; }
 
   // Fixes styling in Firefox/Safari; non-standard properties so not autoprefixed.
   -moz-appearance: none;
@@ -29,8 +34,7 @@
 
   &:focus {
     outline: none;
-    border: 1px solid $blue;
-    box-shadow: 0 0 3px $blue;
+    border-color: $blue;
   }
 
   &.-search, &.is-loading {

--- a/scss/_components/_forms/_text-field.scss
+++ b/scss/_components/_forms/_text-field.scss
@@ -18,15 +18,16 @@
   font-size: $font-medium;
   border: 0;
   border-bottom: 2px solid $med-gray;
-  background-clip: padding-box;
-  padding: 0 ($base-spacing / 4);
+  border-bottom: 2px solid rgba(0, 0, 0, 0.4);
+  background: transparent;
+  padding: 0;
   margin: 0;
   transition: border 0.5s;
 
-  &::-webkit-input-placeholder { font-family: $font-proxima-nova; font-size: $font-regular; color: $light-gray; line-height: 1.8; }
-  &::-moz-placeholder { font-family: $font-proxima-nova;  font-size: $font-regular;color: $light-gray; line-height: 1.8; }
-  &:-moz-placeholder { font-family: $font-proxima-nova; font-size: $font-regular; color: $light-gray; line-height: 1.8; }
-  &:-ms-input-placeholder { font-family: $font-proxima-nova; font-size: $font-regular; color: $light-gray; line-height: 1.8; }
+  &::-webkit-input-placeholder { font-family: $font-proxima-nova; font-size: $font-regular; color: $light-gray; color: rgba(0, 0, 0, 0.3); line-height: 1.8; }
+  &::-moz-placeholder { font-family: $font-proxima-nova;  font-size: $font-regular;color: $light-gray;  color: rgba(0, 0, 0, 0.3);line-height: 1.8; }
+  &:-moz-placeholder { font-family: $font-proxima-nova; font-size: $font-regular; color: $light-gray; color: rgba(0, 0, 0, 0.3); line-height: 1.8; }
+  &:-ms-input-placeholder { font-family: $font-proxima-nova; font-size: $font-regular; color: $light-gray; color: rgba(0, 0, 0, 0.3); line-height: 1.8; }
 
   // Fixes styling in Firefox/Safari; non-standard properties so not autoprefixed.
   -moz-appearance: none;

--- a/scss/_regions/_navigation.scss
+++ b/scss/_regions/_navigation.scss
@@ -50,9 +50,12 @@
       .text-field {
         color: #fff;
         text-shadow: $text-shadow;
-        border: 1px solid #fff;
-        box-shadow: 0 1px 3px rgba(#000, 0.2),
-        inset 0 1px 3px rgba(#000, 0.2);
+
+        @include media($tablet) {
+          &:focus {
+            border-bottom: 2px solid $off-black;
+          }
+        }
       }
 
       .text-field.-search {
@@ -278,25 +281,25 @@
 
   .text-field {
     background-color: transparent;
-    color: #fff;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    border: 1px solid #fff;
-    box-shadow: 0 1px 0 rgba(#000, 0.2),
-    inset 0 1px 0 rgba(#000, 0.2);
+    color: $off-black;
+    border: 0;
     transition: width 0.5s;
 
     @include media($tablet) {
-      width: 100px;
-      color: $off-black;
-      border: 1px solid $off-black;
-      box-shadow: 0 1px 0 rgba(#fff, 0.2),
-      inset 0 1px 0 rgba(#fff, 0.2);
+      width: 32px;
+
+      &:focus {
+        width: 100px;
+        border-bottom: 2px solid $off-black;
+      }
     }
 
     @include media($large) {
-      width: 200px;
+      &:focus {
+        width: 200px;
+      }
     }
+
   }
 
   .text-field.-search {

--- a/scss/_regions/_navigation.scss
+++ b/scss/_regions/_navigation.scss
@@ -287,9 +287,11 @@
 
     @include media($tablet) {
       width: 32px;
+      cursor: pointer;
 
       &:focus {
         width: 100px;
+        cursor: text;
         border-bottom: 2px solid $off-black;
       }
     }
@@ -338,8 +340,7 @@
     list-style-type: none;
 
     @include media($tablet) {
-      // Hide, but preserve horizontal spacing for dropdown items.
-      visibility: hidden;
+      display: none;
       overflow: hidden;
       height: 0;
     }
@@ -404,7 +405,7 @@
     }
 
     ul {
-      visibility: visible;
+      display: block;
       overflow: visible;
       height: auto;
 

--- a/scss/_regions/_navigation.scss
+++ b/scss/_regions/_navigation.scss
@@ -397,6 +397,7 @@
     @include media($tablet) {
       background-color: #fff;
       padding-bottom: ($base-spacing / 2);
+      box-shadow: $box-shadow;
 
       .navigation__dropdown-toggle {
         color: $purple;


### PR DESCRIPTION
# Changes
 - Experimenting with some alternate styling for form fields. Posted to save for later, and for feedback/discussion.

The idea behind this experiment is to make user input feel more personal and fun. We currently use our handwritten font as the "Voice of DoSomething", but perhaps it could be more empowering to use it as the "voice of our members". (Also it makes forms look way less sterile!)

__Not ready for merge.__ :rotating_light:

# Screenshot
![screen shot 2015-03-27 at 12 58 10 pm](https://cloud.githubusercontent.com/assets/583202/6872649/f7d87c0e-d480-11e4-9e6f-906c9bfa0ab7.png)

Also works nicely with inline form pattern:
![screen shot 2015-03-27 at 1 01 48 pm](https://cloud.githubusercontent.com/assets/583202/6872740/790699fa-d481-11e4-96a3-50e30630b988.png)

