### PR TITLE
Fix spacing in Header pattern

### DIFF
--- a/scss/_regions/_header.scss
+++ b/scss/_regions/_header.scss
@@ -168,14 +168,13 @@
       vertical-align: bottom;
 
       @include media($tablet) {
-        bottom: 27px;
         position: absolute;
+        bottom: $base-spacing;
       }
     }
 
     .header__subtitle {
       @include media($tablet) {
-        margin-bottom: 9px;
         width: 80%;
       }
     }
@@ -194,6 +193,8 @@
     }
 
     .header__signup {
+      margin-top: $base-spacing;
+
       @include media($tablet) {
         clear: left;
         float: left;


### PR DESCRIPTION
# Changes
 - Fix spacing in Header pattern between subtitle and signup element. Also replaces arbitrary pixel value on wrapper positioning with `$base-spacing`.

Fixes DoSomething/dosomething#4278.
For review: @DoSomething/front-end 