### PR TITLE
Fix tab display issue on IE8. Closes #410.

### DIFF
--- a/scss/_modules/_tabs.scss
+++ b/scss/_modules/_tabs.scss
@@ -87,12 +87,7 @@
       z-index: 10;
 
       li {
-        margin: 0;
-      }
-
-      a {
-        display: inline-block;
-        padding: ($base-spacing / 4) ($base-spacing / 2);
+        padding: ($base-spacing / 4) 0;
       }
 
       .is-active {


### PR DESCRIPTION
# Changes
 - Fixes overlapping tab titles in IE8. Closes #410 and DoSomething/dosomething#4213.

For review: @DoSomething/front-end 