### PR TITLE
Fix notifications step.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dosomething-neue",
-  "version": "6.4.3",
+  "version": "6.4.4",
   "license": "MIT",
   "engines": {
     "node": "0.10.x"

--- a/wercker.yml
+++ b/wercker.yml
@@ -31,10 +31,9 @@ deploy:
         name: prepare notification
         code: |-
           export PACKAGE_NAME="$(./node_modules/npv/npv.js --name)"
+          export NPM_VERSION="$(./node_modules/npv/npv.js)"
           export PACKAGE_VERSION="$(npm show $NPM_PACKAGE version  2> /dev/null)"
-          if [ "$(./node_modules/npv/npv.js)" = "$(npm show $PACKAGE_NAME version  2> /dev/null)" ]; then
-            export WERCKER_SLACK_NOTIFY_ON="failed"
-          fi
+          if [ "$NPM_VERSION" = "$PACKAGE_VERSION" ]; then export WERCKER_SLACK_NOTIFY_ON="failed"; fi;
   after-steps:
     - sherzberg/slack-notify:
         subdomain: dosomething


### PR DESCRIPTION
Per [Wercker dev center](http://old-devcenter.wercker.com/articles/steps/), if-blocks in steps must be on a single line because code is read line-by-line. Also bumping patch version again.

:cactus: 