### PR TITLE
Wercker: prepare notifications before NPM deploy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dosomething-neue",
-  "version": "6.4.4",
+  "version": "6.4.5",
   "license": "MIT",
   "engines": {
     "node": "0.10.x"

--- a/wercker.yml
+++ b/wercker.yml
@@ -13,6 +13,14 @@ build:
 deploy:
   steps:
     - script:
+        name: prepare notification variables
+        code: |-
+          npm install npv
+          export PACKAGE_NAME="$(./node_modules/npv/npv.js --name)"
+          export NPM_VERSION="$(./node_modules/npv/npv.js)"
+          export PACKAGE_VERSION="$(npm show $NPM_PACKAGE version  2> /dev/null)"
+          if [ "$NPM_VERSION" = "$PACKAGE_VERSION" ]; then export WERCKER_SLACK_NOTIFY_ON="failed"; fi;
+    - script:
         name: build static pattern library
         code: |-
           export NODE_ENV='production'
@@ -27,13 +35,6 @@ deploy:
         username: $NPM_USERNAME
         email: $NPM_EMAIL
         password: $NPM_PASSWORD
-    - script:
-        name: prepare notification
-        code: |-
-          export PACKAGE_NAME="$(./node_modules/npv/npv.js --name)"
-          export NPM_VERSION="$(./node_modules/npv/npv.js)"
-          export PACKAGE_VERSION="$(npm show $NPM_PACKAGE version  2> /dev/null)"
-          if [ "$NPM_VERSION" = "$PACKAGE_VERSION" ]; then export WERCKER_SLACK_NOTIFY_ON="failed"; fi;
   after-steps:
     - sherzberg/slack-notify:
         subdomain: dosomething


### PR DESCRIPTION
# Changes
 - Run notifications step first, so that it can properly check if this is a new NPM deploy.

:cactus: 
