### PR TITLE
Add fallback for modal overlay in IE8.

### DIFF
--- a/scss/_regions/_modal.scss
+++ b/scss/_regions/_modal.scss
@@ -43,3 +43,9 @@
   padding: $base-spacing;
 }
 
+// Add support for modal overlay in IE8
+.modernizr-no-svg .chrome.has-modal {
+  &:after {
+    background: neue-asset-url('images/fallbacks/ie8-rgba-black-50.png');
+  }
+}


### PR DESCRIPTION
# Changes
 - Fixes modal background in IE8. The fallback PNG was removed when we split modals into a separate package. Applying the fix here for now, since I don't want to have to duplicate the fallback PNG across multiple repos.

For review: @DoSomething/front-end 