### PR TITLE
Add try/catch block for cases where click method not supported.

### DIFF
--- a/js/modernizr/label-click.js
+++ b/js/modernizr/label-click.js
@@ -13,7 +13,16 @@ Modernizr.addTest("label-click", function() {
   var testInput = document.createElement("input");
   testInput.setAttribute("type", "checkbox");
   testLabel.appendChild(testInput);
-  testLabel.click();
+
+  try {
+    // Trigger a `click` on the label, so we can check if the
+    // corresponding input becomes checked.
+    testLabel.click();
+  } catch(exception) {
+    // If `DOMElement.click()` is not supported, such as in
+    // PhantomJS, just fail the test.
+    return false;
+  }
 
   return testInput.checked;
 });


### PR DESCRIPTION
# Changes
Add a try/catch block around the `click();` DOM method, since PhantomJS does not support it. The `click()` method is supported in all other browsers we care about for this test, so I don't think it's worth the extra code required to create a cross-browser version.

For review: @DoSomething/front-end 